### PR TITLE
Move dev dependency to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^5.4 || ^7.0 || ^8.0",
         "doctrine/instantiator": "1.4.1",
-        "facebook/facebook-instant-articles-sdk-php": "dev-php8",
-        "phpcompatibility/phpcompatibility-wp": "^2.1"
+        "facebook/facebook-instant-articles-sdk-php": "dev-php8"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^3.0.0",
-        "phpdocumentor/reflection-docblock": "^2.0"
+        "phpdocumentor/reflection-docblock": "^2.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With it in `require`, any consuming package running `composer i --no-dev` will still get all of the PHPCS-related packages installed.