### PR TITLE
Fix change in behaviour for applyFilters()

### DIFF
--- a/src/Facebook/InstantArticles/Utils/Observer.php
+++ b/src/Facebook/InstantArticles/Utils/Observer.php
@@ -150,6 +150,10 @@ class Observer
         if (!isset($this->callbacks[$tag])) {
             return $value;
         }
+        
+        // Uses this to be compatible with PHP < 5.6
+        // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection -- $tag wasn't changed.
+        $args = func_get_args();
 
         // Removes the $tag, since this is not an expected parameter to callbacks.
         array_shift($args);


### PR DESCRIPTION
Reverts part of 3577292dc7cefeaedfed65ae045919c655f72454.

Removing the call to `func_get_args()`, means `$args` was unpopulated.

Instead, we add the call back in, along with an ignore for the PHPCompatibility PHPCS Warning that prompted this change.

See https://3v4l.org/eHIbW for the difference.